### PR TITLE
feat: shift_duration_validator

### DIFF
--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -1,2 +1,20 @@
 module RoutesHelper
+  include CoordinateHelper
+
+  PICKUP_DROPOFF_TIME_HOURS = 0.5
+  MAX_DEVIATION_DISTANCE_MI = 2 / 1.609
+  MAX_SHIFT_DURATION = 10
+
+  def calculate_order_deviation_time(route)
+    deviation_time = MAX_DEVIATION_DISTANCE_MI / route.truck.avg_speed_miles_per_hour
+    deviation_time + PICKUP_DROPOFF_TIME_HOURS
+  end
+
+  def fits_in_shift?(order, route)
+    order_deviation_time = calculate_order_deviation_time(route)
+    total_route_deviation_time = route.orders.map { |order| calculate_order_deviation_time(route) }.sum
+    current_route_time = total_route_deviation_time + route.time_hours
+
+    current_route_time + order_deviation_time < MAX_SHIFT_DURATION
+  end
 end

--- a/app/helpers/routes_helper.rb
+++ b/app/helpers/routes_helper.rb
@@ -10,9 +10,9 @@ module RoutesHelper
     deviation_time + PICKUP_DROPOFF_TIME_HOURS
   end
 
-  def fits_in_shift?(order, route)
+  def fits_in_shift?(_one_order, route)
     order_deviation_time = calculate_order_deviation_time(route)
-    total_route_deviation_time = route.orders.map { |order| calculate_order_deviation_time(route) }.sum
+    total_route_deviation_time = route.orders.map { |_one_order| calculate_order_deviation_time(route) }.sum
     current_route_time = total_route_deviation_time + route.time_hours
 
     current_route_time + order_deviation_time < MAX_SHIFT_DURATION

--- a/test/helpers/routes_helper_test.rb
+++ b/test/helpers/routes_helper_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class RoutesHelperTest < ActiveSupport::TestCase
+  include RoutesHelper
+
+  setup do
+    @route1 = routes(:route1)
+    @order1 = orders(:order1)
+  end
+
+  test "fits_in_shift? returns true when order fits within 10 hour shift duration of route1" do
+    result = fits_in_shift?(@order1, @route1)
+    assert result, true
+  end
+
+  test "fits_in_shift? returns false when order does not fit within 10 hour shift duration of route1" do
+    9.times do
+      @route1.orders << @order1
+    end
+
+    @still_fits = orders(:order1)
+    # Should return true when adding 9 orders
+    result = fits_in_shift?(@still_fits, @route1)
+    assert result, true
+    # add one more
+    @route1.orders << @still_fits
+
+    @doesnt_fit = orders(:order1)
+    result = fits_in_shift?(@doesnt_fit, @route1)
+    assert result, false
+  end
+end


### PR DESCRIPTION
Added two methods in routes_helper: calculate_order_deviation_time, fits_in_shift?

calculate_order_deviation_time calculates the amount of time that the truck takes to travel to the pickup + dropoff locations and the pickup + dropoff time.

fits_in_shift? checks whether the current route's total route time + order_deviation_time exceeds the max shift duration (10 hours)

Added test cases in routes_helpers_test
First test checks that the mock order fits in shift for route 1 and should return true
Second test adds 9 more orders and should return true
Third test adds 1 more order and should return false